### PR TITLE
Add Seedream AI Studio to Commercial Product

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,9 @@ A curated list of recent diffusion models for video generation, editing, restora
 + [Shortodella](https://shortodella.com/)  
   [![Website](https://img.shields.io/badge/Website-9cf)](https://shortodella.com/)
 
++ [Seedream AI Studio](https://seedream4.video/)  
+  [![Website](https://img.shields.io/badge/Website-9cf)](https://seedream4.video/)
+
 ### Video Generation
 + [Helios: Real Real-Time Long Video Generation Model](https://arxiv.org/abs/2603.04379) (Mar., 2026)  
   [![Star](https://img.shields.io/github/stars/PKU-YuanGroup/Helios.svg?style=social&label=Star)](https://github.com/PKU-YuanGroup/Helios)


### PR DESCRIPTION
## Addition

Adds [Seedream AI Studio](https://seedream4.video/) to the **Commercial Product** section.

## About the product

Seedream AI Studio is an integrated AI image + video platform:
- Generates images using ByteDance's Seedream 5.0/4.5/4.0 models
- One-click animates selected images into video clips via Kling 2.1 image-to-video
- Free tier available

It sits alongside products like Kling (KuaiShou) as a complementary consumer platform for AI-powered video creation.