### PR TITLE
Add Riffkit to Commercial Product

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,10 @@ A curated list of recent diffusion models for video generation, editing, restora
 + [Seedream AI Studio](https://seedream4.video/)  
   [![Website](https://img.shields.io/badge/Website-9cf)](https://seedream4.video/)
 
++ [Riffkit](https://riffkit.ai/)  
+  [![Website](https://img.shields.io/badge/Website-9cf)](https://riffkit.ai/)
+  [![GitHub](https://img.shields.io/badge/GitHub-riffkit%2Fskill-181717?logo=github)](https://github.com/riffkit/skill)
+
 ### Video Generation
 + [Helios: Real Real-Time Long Video Generation Model](https://arxiv.org/abs/2603.04379) (Mar., 2026)  
   [![Star](https://img.shields.io/github/stars/PKU-YuanGroup/Helios.svg?style=social&label=Star)](https://github.com/PKU-YuanGroup/Helios)


### PR DESCRIPTION
Adds **Riffkit** — an agent skill for recreating the *formula* of a winning short video.

Riffkit takes one proven short video, studies the hook, pacing, and emotional beats that made it retain viewers, and generates a brand-new video around the user's own product, character, and language (English/Spanish). It never re-uploads the source; the output is an original.

- Open-source skill spec (MIT): https://github.com/riffkit/skill
- Live skill + examples: https://riffkit.ai/SKILL.md
- Rendering runs on Riffkit's hosted backend (account required), consistent with other hosted entries already in the list.

One entry, added to the **Commercial Product** section in the existing format.
