### PR TITLE
Add VideoScore2 (think-before-you-score video eval reward model) to RL for Video Generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3159,6 +3159,10 @@ A curated list of recent diffusion models for video generation, editing, restora
   [![Star](https://img.shields.io/github/stars/TIGER-AI-Lab/VideoScore.svg?style=social&label=Star)](https://github.com/TIGER-AI-Lab/VideoScore/)
   [![arXiv](https://img.shields.io/badge/arXiv-b31b1b.svg)](https://arxiv.org/abs/2406.15252)
   [![Website](https://img.shields.io/badge/Website-9cf)](https://tiger-ai-lab.github.io/VideoScore/)
++ [VideoScore2: Think before You Score in Generative Video Evaluation](https://arxiv.org/abs/2509.22799) (Sep., 2025)
+  [![Star](https://img.shields.io/github/stars/TIGER-AI-Lab/VideoScore2.svg?style=social&label=Star)](https://github.com/TIGER-AI-Lab/VideoScore2/)
+  [![arXiv](https://img.shields.io/badge/arXiv-b31b1b.svg)](https://arxiv.org/abs/2509.22799)
+  [![Website](https://img.shields.io/badge/Website-9cf)](https://tiger-ai-lab.github.io/VideoScore2/)
 
 ### Policy Learning
 


### PR DESCRIPTION
Adds **VideoScore2** to the "Reinforcement Learning for Video Generation" section, right after the existing VideoScore entry.

VideoScore2 (arXiv:2509.22799, TIGER-AI-Lab) is a multi-dimensional, interpretable reward model for generated video. It scores visual quality, text-to-video alignment, and physical/common-sense consistency with chain-of-thought rationales, trained via SFT + GRPO on VideoFeedback2 (27,168 human-annotated videos with reasoning traces). It functions as a reward model for aligning/controllable video generation, so it fits alongside the other RLHF/reward-feedback works in this section and directly follows the VideoScore v1 entry already listed.

- Paper: https://arxiv.org/abs/2509.22799
- Code: https://github.com/TIGER-AI-Lab/VideoScore2
- Project: https://tiger-ai-lab.github.io/VideoScore2/
- Model: https://huggingface.co/TIGER-Lab/VideoScore2

Kept the formatting consistent with neighboring entries (Star / arXiv / Website badges). Thanks for maintaining this list!