### PR TITLE
Add SEELE TV to Commercial Product

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,9 @@ A curated list of recent diffusion models for video generation, editing, restora
   [![Website](https://img.shields.io/badge/Website-9cf)](https://riffkit.ai/)
   [![GitHub](https://img.shields.io/badge/GitHub-riffkit%2Fskill-181717?logo=github)](https://github.com/riffkit/skill)
 
++ [SEELE TV](https://seele.tv/)
+  [![Website](https://img.shields.io/badge/Website-9cf)](https://seele.tv/)
+
 ### Video Generation
 + [Helios: Real Real-Time Long Video Generation Model](https://arxiv.org/abs/2603.04379) (Mar., 2026)  
   [![Star](https://img.shields.io/github/stars/PKU-YuanGroup/Helios.svg?style=social&label=Star)](https://github.com/PKU-YuanGroup/Helios)


### PR DESCRIPTION
Adds SEELE TV to the Commercial Product section using the existing list format.\n\nSEELE TV is a cinematic AI video studio focused on scene consistency and shot-level camera control. The entry links to the official product site and uses a concise, factual description.