### PR TITLE
Add CachedSearch (arXiv 2607.23159) to Efficient Video Generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1206,6 +1206,11 @@ A curated list of recent diffusion models for video generation, editing, restora
   [![arXiv](https://img.shields.io/badge/arXiv-b31b1b.svg)](https://arxiv.org/abs/2203.09481)
 
 ### Efficient Video Generation
++ [CachedSearch: Training-Free Cached Exploration for Test-Time Search in Video Diffusion](https://arxiv.org/abs/2607.23159) (Jul., 2026)   
+  [![Star](https://img.shields.io/github/stars/shreshthsaini/CachedSearch.svg?style=social&label=Star)](https://github.com/shreshthsaini/CachedSearch)
+  [![arXiv](https://img.shields.io/badge/arXiv-b31b1b.svg)](https://arxiv.org/abs/2607.23159)
+  [![Website](https://img.shields.io/badge/Website-9cf)](https://shreshthsaini.github.io/CachedSearch/)
+
 + [SpargeAttn: Accurate Sparse Attention Accelerating Any Model Inference](https://arxiv.org/abs/2502.18137) (Feb., 2025)   
   [![Star](https://img.shields.io/github/stars/thu-ml/SpargeAttn)](https://github.com/thu-ml/SpargeAttn)
   [![arXiv](https://img.shields.io/badge/arXiv-b31b1b.svg)](https://arxiv.org/abs/2502.18137)


### PR DESCRIPTION
Adds one entry to the **Efficient Video Generation** section.

**CachedSearch: Training-Free Cached Exploration for Test-Time Search in Video Diffusion**
Shreshth Saini, Neil Birkbeck, Yilin Wang, Balu Adsumilli, Alan C. Bovik

- Paper: https://arxiv.org/abs/2607.23159
- Code: https://github.com/shreshthsaini/CachedSearch
- Project page: https://shreshthsaini.github.io/CachedSearch/

The paper studies whether training-free caching corrupts verifier rankings in video test-time search, then uses that result to explore every candidate under aggressive caching and re-generate only the winner at full compute. At N=8 it captures 94.7% of best-of-N's gain at 63% of the cost. Results span Wan, LTX, CogVideoX, and Hunyuan from 1.3B to 14B.

Entry follows the existing format in that section (title link, date, Star badge, arXiv badge, Website badge).

Disclosure: I am an author of this paper. Happy to move it to a different section or reword the entry if you prefer.